### PR TITLE
FIX: Property normal on MeshVertex is readonly and can not be set

### DIFF
--- a/ImportCSV.py
+++ b/ImportCSV.py
@@ -534,12 +534,6 @@ def createMesh(
     mesh = bpy.data.meshes.new("name")
     mesh.from_pydata(vertices, [], faces)
 
-    # Normals
-    for vertexIndex in range(len(mesh.vertices)):
-        curNormal = normals[vertexIndex]
-        curNormalNorm = list(map(lambda x: x / normalNormalize, curNormal)) # Bad variable name, I know...
-        mesh.vertices[vertexIndex].normal = curNormalNorm
-
     # UV Maps
     for uvIndex in range(len(uvs)):
         uvLayer = mesh.uv_layers.new(name=f"UV{uvIndex}")


### PR DESCRIPTION
Fixes #1 
Normals on MeshVertex should not be manually modified as by https://projects.blender.org/blender/blender/issues/97018. The script still works anyways.